### PR TITLE
Change link of documentation to docs.rs

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             <div id="navbarMenu" class="navbar-menu" style="background: transparent;">
               <div class="navbar-end">
                 <span class="navbar-item">
-                  <a class="button is-white is-outlined is-fullwidth" href="/docs/stable/relm4">
+                  <a class="button is-white is-outlined is-fullwidth" href="https://docs.rs/relm4/">
                     <span class="icon">
                       <i class="mdi mdi-file-document"></i>
                     </span>


### PR DESCRIPTION
Merging this is blocked until 0.5 is released on crates.io!

The documentation of all relm4 crates higher than 0.5 will build on docs.rs. The old documentation is deprecated so the link on the website needs to point to the new docs.rs URL.